### PR TITLE
[FE]スキップ時2人目のメッセージが表示されない不具合修正

### DIFF
--- a/frontend/src/components/messages/Letter/ThLetter.vue
+++ b/frontend/src/components/messages/Letter/ThLetter.vue
@@ -63,6 +63,17 @@ function init() {
   }
 }
 
+
+const stop = watch(() => {
+  return props.noAnimation
+}, async (newNoAnimation) => {
+  if (newNoAnimation) {
+    await nextTick();
+    emits('draw')
+    stop()
+  }
+});
+
 init();
 
 onMounted(async () => {
@@ -115,16 +126,14 @@ onMounted(async () => {
         v-for="line, index in lines"
         :key="index"
       >
-        <BaseText
+        <span
           v-if="noAnimation"
-          class="text-lg"
         >
           {{ line }}
-        </BaseText>
+        </span>
         <template v-else>
           <TypeWriter
             v-if="isShowRow(index)"
-            class="text-lg"
             :text="line"
             :type-speed="1"
             @finish="onFinish"

--- a/frontend/src/components/messages/MessageRow/MessageRow.vue
+++ b/frontend/src/components/messages/MessageRow/MessageRow.vue
@@ -6,7 +6,7 @@
 <template>
   <div
     class="tracking-wide text-base message-row min-h-15 px-8 flex items-center
-    border-b-1 border-dotted border-grey"
+    border-b-1 border-dotted border-grey font-semibold"
   >
     <slot />
   </div>
@@ -15,7 +15,6 @@
 <style scoped>
 .message-row {
   font-family: 'Zen Kurenaido', sans-serif;
-  font-weight: 500;
   color: #121212;
 }
 </style>

--- a/frontend/src/components/messages/MessageRow/MessageRowBody.vue
+++ b/frontend/src/components/messages/MessageRow/MessageRowBody.vue
@@ -8,7 +8,7 @@ import MessageRow from './MessageRow.vue';
 
 <template>
   <MessageRow>
-    <p>
+    <p class="text-lg font-semibold">
       <slot />
     </p>
   </MessageRow>


### PR DESCRIPTION
## 概要

<!-- どんな変更をしたのか、簡潔に記述してください -->

タイピングのアニメーションをスキップした際に2人目のメッセージが表示されないバグを修正

---

## 関連 Issue

<!-- 関連するIssueがあれば記載（自動でCloseしたい場合は `Closes #xx` を使う） -->

Closes #

---

## 変更内容

<!-- 主な変更点・追加機能など -->

- [ ] 新しいルーティングの追加
- [ ] Vue コンポーネントの作成
- [ ] バリデーションロジックの追加

---

## 確認事項

- [ ] ローカルで動作確認済み
- [ ] DB マイグレーションが含まれる場合、反映確認済み
- [ ] セキュリティやアクセシビリティも意識できている

---

## スクリーンショット（あれば）

<!-- UI変更がある場合は、画面キャプチャを貼ってください -->
